### PR TITLE
Distinguish materials for same-name textures from different folders

### DIFF
--- a/core/materials.py
+++ b/core/materials.py
@@ -55,7 +55,8 @@ def find_material_with_image(image):
     """Return existing material that uses this image, or None"""
     expected_name = f"IMG_{image.name}"
     mat = bpy.data.materials.get(expected_name)
-    if mat:
+    is_match = mat and get_image_from_material(mat) is image
+    if is_match:
         debug_log(f"[FindMaterial] image={image.name!r} -> lookup={expected_name!r} -> FOUND")
         return mat
     # HACK: Blender appends .001/.002/etc. to image datablock names when there
@@ -68,7 +69,8 @@ def find_material_with_image(image):
     if base_name != image.name:
         fallback_name = f"IMG_{base_name}"
         mat = bpy.data.materials.get(fallback_name)
-        if mat:
+        is_match = mat and get_image_from_material(mat) is image
+        if is_match:
             debug_log(f"[FindMaterial] image={image.name!r} -> fallback={fallback_name!r} -> FOUND")
             return mat
     debug_log(f"[FindMaterial] image={image.name!r} -> NOT FOUND")

--- a/handlers/file_browser.py
+++ b/handlers/file_browser.py
@@ -90,9 +90,18 @@ def consolidate_duplicate_materials():
     replacements = {}
     for base_name, duplicates in material_groups.items():
         canonical = bpy.data.materials[base_name]
-        for suffix_num, mat in duplicates:
-            if mat != canonical:
-                replacements[mat] = canonical
+        canonical_image = get_image_from_material(canonical)
+
+        if canonical_image is None:
+            continue
+
+        for suffix_num, candidate in duplicates:
+            if candidate is canonical:
+                continue
+
+            is_duplicate = get_image_from_material(candidate) is canonical_image
+            if is_duplicate:
+                replacements[candidate] = canonical
 
     if not replacements:
         return

--- a/tests/test_material_lookup.py
+++ b/tests/test_material_lookup.py
@@ -1,0 +1,66 @@
+import os
+import shutil
+import tempfile
+
+import bpy
+
+from ..core.materials import create_material_with_image, find_material_with_image
+from ..handlers import file_browser
+from ..handlers.file_browser import consolidate_duplicate_materials
+from .base_test import AnvilTestCase
+from .helpers import TEXTURE_PATH
+
+
+class MaterialLookupTest(AnvilTestCase):
+    """Verify materials are keyed by image identity, not just by filename."""
+
+    def setUp(self):
+        super().setUp()
+        file_browser._last_material_count = 0
+        self._tmp_dir = tempfile.mkdtemp(prefix="anvil_material_lookup_")
+        self._dark_path = os.path.join(self._tmp_dir, "Dark", "texture_01.png")
+        self._green_path = os.path.join(self._tmp_dir, "Green", "texture_01.png")
+        os.makedirs(os.path.dirname(self._dark_path))
+        os.makedirs(os.path.dirname(self._green_path))
+        shutil.copyfile(TEXTURE_PATH, self._dark_path)
+        shutil.copyfile(TEXTURE_PATH, self._green_path)
+
+    def tearDown(self):
+        shutil.rmtree(self._tmp_dir, ignore_errors=True)
+        super().tearDown()
+
+    def test_find_material_returns_none_for_cross_folder_same_name(self):
+        """find_material_with_image distinguishes images with shared basename."""
+        create_material_with_image(bpy.data.images.load(self._dark_path, check_existing=True))
+        green_image = bpy.data.images.load(self._green_path, check_existing=True)
+
+        self.assertIsNone(find_material_with_image(green_image))
+
+    def test_find_material_reuses_existing_for_same_image(self):
+        """Reloading the same file returns the same material."""
+        image = bpy.data.images.load(self._dark_path, check_existing=True)
+        material = create_material_with_image(image)
+        reloaded = bpy.data.images.load(self._dark_path, check_existing=True)
+
+        self.assertIs(find_material_with_image(reloaded), material)
+
+    def test_consolidate_keeps_cross_folder_materials_separate(self):
+        """consolidate must not merge IMG_X and IMG_X.001 referencing different images."""
+        create_material_with_image(bpy.data.images.load(self._dark_path, check_existing=True))
+        create_material_with_image(bpy.data.images.load(self._green_path, check_existing=True))
+
+        consolidate_duplicate_materials()
+
+        self.assertIn("IMG_texture_01.png", bpy.data.materials)
+        self.assertIn("IMG_texture_01.png.001", bpy.data.materials)
+
+    def test_consolidate_still_merges_object_duplicates(self):
+        """consolidate still merges IMG_X.001 with IMG_X when both reference the same image."""
+        image = bpy.data.images.load(self._dark_path, check_existing=True)
+        canonical = create_material_with_image(image)
+        canonical.copy()
+
+        consolidate_duplicate_materials()
+
+        self.assertIn("IMG_texture_01.png", bpy.data.materials)
+        self.assertNotIn("IMG_texture_01.png.001", bpy.data.materials)


### PR DESCRIPTION
# Problem
In the current version, if you apply textures that share names but from different folders, it will apply the material from whichever folder was opened first.

You can reproduce with https://kenney.nl/assets/prototype-textures, its themed subfolders (Dark/, Green/, Red/…) all contain same named files like `texture_01.png`.

# Solution
Both `find_material_with_image` and `consolidate_duplicate_materials` used IMG_X as their cache key. Fixed by adding an identity check - the material's TEX_IMAGE node must reference the exact image datablock, not just match by name.

# Alternatives
* Compare by filepath instead of datablock identity - redundant, `bpy.data.images.load(current_path, check_existing=True)` already dedupes by filepath
* Scan all materials by image identity instead of name lookup - expensive


# Test
`tests/test_material_lookup.py` adds four tests: 
cross-folder lookup
same-image reuse
consolidate keeping cross-folder materials separate
consolidate still merging object-duplicates

```
blender --enable-event-simulate --python tests/run_tests.py -- test_material_lookup
```
# Videos
Before:
https://github.com/user-attachments/assets/4f10816c-6372-4739-b7f7-123f954ee9ec

After:
https://github.com/user-attachments/assets/86405a4c-7a40-4e8b-a744-e26befef09a9
