### PR TITLE
Fix texture browser UI scale text

### DIFF
--- a/core/modal_image_grid.py
+++ b/core/modal_image_grid.py
@@ -1432,6 +1432,16 @@ def image_grid_widget_unit(ui_scale, pixel_size):
     return int(math.floor(18.0 * ui_scale + 0.5)) + (2 * int(pixel_size))
 
 
+def image_grid_scaled_font_size(font_size, ui_scale):
+    try:
+        scale = float(ui_scale)
+    except (TypeError, ValueError):
+        scale = 1.0
+    if scale <= 0.0:
+        scale = 1.0
+    return max(1.0, float(font_size) * scale)
+
+
 def image_grid_cell_padding(widget_unit):
     return widget_unit
 
@@ -1540,6 +1550,8 @@ def _image_grid_canvas_metrics_with_reserved_width(
     viewport_height = max(1, grid_top - grid_bottom)
     max_scroll = max(0, content_height - viewport_height)
     return {
+        "ui_scale": ui_scale,
+        "pixel_size": pixel_size,
         "widget_unit": widget_unit,
         "region_width": region_width,
         "icon_size": icon_size,

--- a/core/modal_image_grid.py
+++ b/core/modal_image_grid.py
@@ -1432,16 +1432,6 @@ def image_grid_widget_unit(ui_scale, pixel_size):
     return int(math.floor(18.0 * ui_scale + 0.5)) + (2 * int(pixel_size))
 
 
-def image_grid_scaled_font_size(font_size, ui_scale):
-    try:
-        scale = float(ui_scale)
-    except (TypeError, ValueError):
-        scale = 1.0
-    if scale <= 0.0:
-        scale = 1.0
-    return max(1.0, float(font_size) * scale)
-
-
 def image_grid_cell_padding(widget_unit):
     return widget_unit
 

--- a/prefabs/browser.py
+++ b/prefabs/browser.py
@@ -10,6 +10,7 @@ from ..core.modal_image_grid import (
     draw_image_grid_rect,
     draw_image_grid_text,
     draw_image_grid_texture,
+    image_grid_scaled_font_size,
 )
 from ..core.workspace_check import is_level_design_workspace
 from .previews import (
@@ -218,6 +219,10 @@ def _draw_prefab_browser_cell(rect, metrics):
     icon_y = label_y + metrics["line_height"] + 6
     icon_height = max(1, min(icon_space, int(y + height - padding - icon_y)))
     icon_x = x + (width - icon_space) / 2
+    ui_scale = metrics["ui_scale"]
+    meta_font_size = image_grid_scaled_font_size(11, ui_scale)
+    no_preview_font_size = image_grid_scaled_font_size(12, ui_scale)
+    label_font_size = image_grid_scaled_font_size(13, ui_scale)
 
     gpu.state.blend_set('ALPHA')
     try:
@@ -250,7 +255,7 @@ def _draw_prefab_browser_cell(rect, metrics):
                 icon_x,
                 icon_y + icon_height / 2 - 6,
                 icon_space,
-                12,
+                no_preview_font_size,
                 (0.70, 0.70, 0.70, 0.90),
                 'CENTER',
             )
@@ -259,7 +264,7 @@ def _draw_prefab_browser_cell(rect, metrics):
             x + padding + 1,
             label_y - 1,
             width - padding * 2,
-            13,
+            label_font_size,
             (0.0, 0.0, 0.0, 0.75),
             'CENTER',
         )
@@ -268,7 +273,7 @@ def _draw_prefab_browser_cell(rect, metrics):
             x + padding,
             label_y,
             width - padding * 2,
-            13,
+            label_font_size,
             (0.96, 0.96, 0.96, 1.0),
             'CENTER',
         )
@@ -277,7 +282,7 @@ def _draw_prefab_browser_cell(rect, metrics):
             x + padding + 1,
             meta_y - 1,
             width - padding * 2,
-            11,
+            meta_font_size,
             (0.0, 0.0, 0.0, 0.70),
             'CENTER',
         )
@@ -286,7 +291,7 @@ def _draw_prefab_browser_cell(rect, metrics):
             x + padding,
             meta_y,
             width - padding * 2,
-            11,
+            meta_font_size,
             (0.68, 0.70, 0.73, 1.0),
             'CENTER',
         )

--- a/prefabs/browser.py
+++ b/prefabs/browser.py
@@ -10,7 +10,6 @@ from ..core.modal_image_grid import (
     draw_image_grid_rect,
     draw_image_grid_text,
     draw_image_grid_texture,
-    image_grid_scaled_font_size,
 )
 from ..core.workspace_check import is_level_design_workspace
 from .previews import (
@@ -220,9 +219,9 @@ def _draw_prefab_browser_cell(rect, metrics):
     icon_height = max(1, min(icon_space, int(y + height - padding - icon_y)))
     icon_x = x + (width - icon_space) / 2
     ui_scale = metrics["ui_scale"]
-    meta_font_size = image_grid_scaled_font_size(11, ui_scale)
-    no_preview_font_size = image_grid_scaled_font_size(12, ui_scale)
-    label_font_size = image_grid_scaled_font_size(13, ui_scale)
+    meta_font_size = 11 * ui_scale
+    no_preview_font_size = 12 * ui_scale
+    label_font_size = 13 * ui_scale
 
     gpu.state.blend_set('ALPHA')
     try:

--- a/texture_browser/browser.py
+++ b/texture_browser/browser.py
@@ -12,7 +12,6 @@ from ..core.modal_image_grid import (
     draw_image_grid_rect,
     draw_image_grid_text,
     draw_image_grid_texture_display,
-    image_grid_scaled_font_size,
 )
 from ..core.logging import debug_log
 from ..core.workspace_check import (
@@ -685,10 +684,10 @@ def _draw_texture_browser_cell(rect, metrics):
     icon_height = max(1, min(icon_space, int(y + height - padding - icon_y)))
     icon_x = x + (width - icon_space) / 2
     ui_scale = metrics["ui_scale"]
-    meta_font_size = image_grid_scaled_font_size(11, ui_scale)
-    no_preview_font_size = image_grid_scaled_font_size(12, ui_scale)
-    label_font_size = image_grid_scaled_font_size(13, ui_scale)
-    action_font_size = image_grid_scaled_font_size(15, ui_scale)
+    meta_font_size = 11 * ui_scale
+    no_preview_font_size = 12 * ui_scale
+    label_font_size = 13 * ui_scale
+    action_font_size = 15 * ui_scale
 
     gpu.state.blend_set('ALPHA')
     try:

--- a/texture_browser/browser.py
+++ b/texture_browser/browser.py
@@ -12,6 +12,7 @@ from ..core.modal_image_grid import (
     draw_image_grid_rect,
     draw_image_grid_text,
     draw_image_grid_texture_display,
+    image_grid_scaled_font_size,
 )
 from ..core.logging import debug_log
 from ..core.workspace_check import (
@@ -623,7 +624,7 @@ def _point_in_rect(rect, x, y):
     )
 
 
-def _draw_texture_browser_file_icon(icon_x, icon_y, icon_w, icon_h, suffix):
+def _draw_texture_browser_file_icon(icon_x, icon_y, icon_w, icon_h, suffix, font_size):
     body_w = icon_w * 0.58
     body_h = icon_h * 0.72
     body_x = icon_x + (icon_w - body_w) / 2
@@ -637,7 +638,7 @@ def _draw_texture_browser_file_icon(icon_x, icon_y, icon_w, icon_h, suffix):
         body_x + 3,
         body_y + body_h * 0.42,
         body_w - 6,
-        11,
+        font_size,
         (0.82, 0.86, 0.90, 0.95),
         'CENTER',
     )
@@ -683,6 +684,11 @@ def _draw_texture_browser_cell(rect, metrics):
     icon_y = label_y + metrics["line_height"] + 6
     icon_height = max(1, min(icon_space, int(y + height - padding - icon_y)))
     icon_x = x + (width - icon_space) / 2
+    ui_scale = metrics["ui_scale"]
+    meta_font_size = image_grid_scaled_font_size(11, ui_scale)
+    no_preview_font_size = image_grid_scaled_font_size(12, ui_scale)
+    label_font_size = image_grid_scaled_font_size(13, ui_scale)
+    action_font_size = image_grid_scaled_font_size(15, ui_scale)
 
     gpu.state.blend_set('ALPHA')
     try:
@@ -712,12 +718,19 @@ def _draw_texture_browser_cell(rect, metrics):
                     icon_x,
                     icon_y + icon_height / 2 - 6,
                     icon_space,
-                    12,
+                    no_preview_font_size,
                     (0.70, 0.70, 0.70, 0.90),
                     'CENTER',
                 )
         else:
-            _draw_texture_browser_file_icon(icon_x, icon_y, icon_space, icon_height, rect["suffix"])
+            _draw_texture_browser_file_icon(
+                icon_x,
+                icon_y,
+                icon_space,
+                icon_height,
+                rect["suffix"],
+                meta_font_size,
+            )
 
         if not rect["is_folder"]:
             button_rect = _texture_browser_collection_button_rect(rect, metrics)
@@ -733,7 +746,7 @@ def _draw_texture_browser_cell(rect, metrics):
                 button_rect["x"],
                 button_rect["y"] + 3,
                 button_rect["w"],
-                15,
+                action_font_size,
                 (0.95, 0.97, 1.0, 1.0),
                 'CENTER',
             )
@@ -743,7 +756,7 @@ def _draw_texture_browser_cell(rect, metrics):
             x + padding + 1,
             label_y - 1,
             width - padding * 2,
-            13,
+            label_font_size,
             (0.0, 0.0, 0.0, 0.75),
             'CENTER',
         )
@@ -752,7 +765,7 @@ def _draw_texture_browser_cell(rect, metrics):
             x + padding,
             label_y,
             width - padding * 2,
-            13,
+            label_font_size,
             (0.96, 0.96, 0.96, 1.0),
             'CENTER',
         )
@@ -761,7 +774,7 @@ def _draw_texture_browser_cell(rect, metrics):
             x + padding + 1,
             meta_y - 1,
             width - padding * 2,
-            11,
+            meta_font_size,
             (0.0, 0.0, 0.0, 0.70),
             'CENTER',
         )
@@ -770,7 +783,7 @@ def _draw_texture_browser_cell(rect, metrics):
             x + padding,
             meta_y,
             width - padding * 2,
-            11,
+            meta_font_size,
             (0.68, 0.70, 0.73, 1.0),
             'CENTER',
         )


### PR DESCRIPTION
As an old man, I have to scale blender to a 4k monitor and the texture folder names did not apply blender settings correctly. This is a small fix, but hopefully helpful for others too! Also, I appreciate the great plugin, keep it up! )